### PR TITLE
0.5 Update

### DIFF
--- a/src/Juliet.jl
+++ b/src/Juliet.jl
@@ -319,12 +319,16 @@ function setup_function_file(question::Types.FunctionQuestion)
 		end
 	end
 
-	@windows_only Util.run(`explorer.exe $file`; whitelist=[1])
-	@linux_only run(`xdg-open $file`)
-	@osx_only try
-		run(`open $file`)
-	catch
-		run(`open -a TextEdit $file`)
+ 	@static if is_windows()
+		Util.run(`explorer.exe $file`; whitelist=[1])
+  elseif is_linux()
+		run(`xdg-open $file`)
+	elseif is_apple()
+		try
+			run(`open $file`)
+		catch
+			run(`open -a TextEdit $file`)
+		end
 	end
 end
 


### PR DESCRIPTION
Just a small tweak that was needed to remove dep warns on 0.5. Might be a good idea to make the switch wholesale, but we could also throw Compat in.

I can't use this on 0.5 yet due to an error `ERROR: UndefRefError: access to undefined reference` when running `juliet()`. Not sure if that's a 0.5-specific thing or not.
